### PR TITLE
can now handle a few taxa not matching genus_species and still work

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: MonoPhy
 Type: Package
 Title: Allows to Explore Monophyly (or Lack of it) of Taxonomic Groups in a Phylogeny
-Version: 1.3
-Date: 2016-08-25
+Version: 1.4
+Date: 2018-07-17
 Author: Orlando Schwery
 Maintainer: Orlando Schwery <oschwery@vols.utk.edu>
 Depends: ape, phytools, phangorn, RColorBrewer, taxize

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,7 @@ Version: 1.4
 Date: 2018-07-17
 Author: Orlando Schwery
 Maintainer: Orlando Schwery <oschwery@vols.utk.edu>
-Depends: ape, phytools, phangorn, RColorBrewer, taxize
+Depends: ape, phytools, phangorn, RColorBrewer, taxize, plyr
 Description: Requires rooted resolved phylogeny as input and creates a table of genera, their monophyly-status, which taxa cause problems in monophyly etc. Different information can be extracted from the output and a plot function allows visualization of the results in a number of ways.
 License: GPL-3
 Suggests: knitr, testthat, spacodiR, rmarkdown

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,4 +1,4 @@
-export(AssessMonophyly, CollapseMonophyletics, GetSummaryMonophyly, GetResultMonophyly, GetIntruderTaxa, GetIntruderTips, GetOutlierTaxa, GetOutlierTips, GetAncNodes, PlotMonophyly)
+export(AssessMonophyly, CollapseMonophyletics, GetSummaryMonophyly, GetResultMonophyly, GetIntruderTaxa, GetIntruderTips, GetOutlierTaxa, GetOutlierTips, GetAncNodes, PlotMonophyly, GenerateTaxonomy)
 
 import(ape, phytools, RColorBrewer)
 
@@ -6,3 +6,4 @@ importFrom("taxize", tax_name)
 importFrom("phangorn", Children)
 importFrom("grDevices", "dev.off", "pdf", "rainbow")
 importFrom("graphics", "layout", "par", "plot")
+importFrom("plyr", "dplyr")

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -2,8 +2,8 @@ export(AssessMonophyly, CollapseMonophyletics, GetSummaryMonophyly, GetResultMon
 
 import(ape, phytools, RColorBrewer)
 
-importFrom("taxize", tax_name)
+importFrom("taxize", "tax_name", "classification")
 importFrom("phangorn", Children)
 importFrom("grDevices", "dev.off", "pdf", "rainbow")
 importFrom("graphics", "layout", "par", "plot")
-importFrom("plyr", "dplyr")
+importFrom("plyr", "rbind.fill")

--- a/R/GenerateTaxonomy.R
+++ b/R/GenerateTaxonomy.R
@@ -1,0 +1,12 @@
+GenerateTaxonomy <- function(tree, taxizepref="ncbi") {
+  species <- tree$tip.label
+  taxonomies <- taxize::classification(species, db=taxizedb, rows=1)
+  for (i in sequence(length(taxonomies))) {
+    tax.vector <- taxonomies[[i]]$name
+
+    names(tax.vector) <- make.names(taxonomies[[i]]$rank, unique=TRUE)
+    taxonomies[[i]] <- data.frame(t(rev(tax.vector)), stringsAsFactors=FALSE)
+  }
+  final.taxonomy <- plyr::rbind.fill(taxonomies)
+  return(final.taxonomy)
+}

--- a/R/GenerateTaxonomy.R
+++ b/R/GenerateTaxonomy.R
@@ -1,12 +1,21 @@
 GenerateTaxonomy <- function(tree, taxizepref="ncbi") {
   species <- tree$tip.label
-  taxonomies <- taxize::classification(species, db=taxizedb, rows=1)
+  taxonomies <- taxize::classification(species, db=taxizepref, rows=1)
+  bad.ones <- c()
   for (i in sequence(length(taxonomies))) {
-    tax.vector <- taxonomies[[i]]$name
-
-    names(tax.vector) <- make.names(taxonomies[[i]]$rank, unique=TRUE)
-    taxonomies[[i]] <- data.frame(t(rev(tax.vector)), stringsAsFactors=FALSE)
+    if (class(taxonomies[[i]]) == "logical") {
+      bad.ones <- c(bad.ones,i)
+    } else {
+      tax.vector <- taxonomies[[i]]$name
+      names(tax.vector) <- make.names(taxonomies[[i]]$rank, unique=TRUE)
+      taxonomies[[i]] <- data.frame(t(rev(tax.vector)), stringsAsFactors=FALSE)
+    }
+  }
+  if(length(bad.ones)>0) {
+    warning(paste("The following taxa had no matches:", paste(bad.ones, collapse=", ")))
+    taxonomies <- taxonomies[-bad.ones]
   }
   final.taxonomy <- plyr::rbind.fill(taxonomies)
+  final.taxonomy[(1+nrow(final.taxonomy)):(nrow(final.taxonomy)+length(bad.ones)),1] <- gsub("_", " ", names(taxonomies)[bad.ones])
   return(final.taxonomy)
 }

--- a/man/AssessMonophyly.Rd
+++ b/man/AssessMonophyly.Rd
@@ -9,7 +9,7 @@ Requires rooted phylogeny as input and creates a table of taxa, their monophyly-
 \usage{
 AssessMonophyly (tree, taxonomy=NULL, verbosity=5, outliercheck=TRUE,
 outlierlevel=0.5, taxizelevel= NULL, taxizedb='ncbi', taxizepref='ncbi',
-taxask=FALSE, taxverbose=FALSE)
+taxask=FALSE, taxverbose=FALSE, excludeproblematic=FALSE)
 }
 \arguments{
   \item{tree}{
@@ -41,6 +41,9 @@ If taxonomy is set to 'taxize', the called function 'tax_name' may find several 
 }
   \item{taxverbose}{
 If taxonomy is set to 'taxize', the called function 'tax_name' can display the progress, i.e. the names that are being queried and the success of the query. The default for this is FALSE, in which case nothing will be displayed while querrying.
+}
+  \item{excludeproblematic}{
+If TRUE, this will exclude taxa that do not follow the 'genus_species' format, unless that would leave a tree with two or fewer tips (in which case it throws an error).
 }
 }
 \details{

--- a/man/GenerateTaxonomy.Rd
+++ b/man/GenerateTaxonomy.Rd
@@ -1,0 +1,39 @@
+\name{GenerateTaxonomy }
+\alias{GenerateTaxonomy}
+\title{
+Generate a taxonomy table for all the taxa in a tree
+}
+\description{
+Requires rooted phylogeny as input and creates a data.frame of the taxonomic hierarchy (one row per species)
+}
+\usage{
+GenerateTaxonomy(tree, taxizedb='ncbi', purgerankless=FALSE)
+}
+\arguments{
+  \item{tree}{
+An object of type 'phy', a rooted phylogeny. Multifurcating trees are accepted, but will be dealt with in a conservative manner (i.e. if different taxa share a multifurcation, they will be considered non-monophyletic) If tip labels are in the format 'genus_species', the function can extract the genus names and check their monophyly. If tip labels are in another format or if the monophyly of other taxonomic groups should be tested, a taxonomy file (see 'taxonomy') is required.
+}
+  \item{taxizepref}{
+Your choice of database: could be one of 'ncbi, itis, eol, col, tropicos, gbif, nbn, worms, natserv, bold,' or 'wiki'. See ?taxize::classification for more info.
+}
+\item{purgerankless}{
+Some databases return entries for unnamed ranks: NCBI returns a level for "cellular organisms" that has no formal rank. If TRUE, such entries are deleted.
+}
+}
+\details{
+The function uses 'taxize::classification' to extract information for each species. In the case of multiple names for a species, it uses the first.
+}
+\value{
+The output object of the function is a data.frame with one row per species on the tree and one column per rank (some species may have NA for some ranks). Note that it will return an object with many more levels than AssessMonophyly will use, so subset.
+}
+\author{
+Brian O'Meara
+}
+\seealso{
+\code{\link{GetAncNodes}}, \code{\link{GetIntruderTaxa}}, \code{\link{GetIntruderTips}}, \code{\link{GetOutlierTaxa}}, \code{\link{GetOutlierTips}},\code{\link{GetResultMonophyly}}, \code{\link{GetSummaryMonophyly}}, \code{\link{MonophylyData}}, \code{\link{PlotMonophyly}}, \code{\link{MonoPhy-package}}
+}
+\examples{
+data(Ericactree)  # load tree
+taxonomy <- GenerateTaxonomy(Ericactree)
+print(head(taxonomy))
+}

--- a/man/GenerateTaxonomy.Rd
+++ b/man/GenerateTaxonomy.Rd
@@ -7,7 +7,7 @@ Generate a taxonomy table for all the taxa in a tree
 Requires rooted phylogeny as input and creates a data.frame of the taxonomic hierarchy (one row per species)
 }
 \usage{
-GenerateTaxonomy(tree, taxizedb='ncbi', purgerankless=FALSE)
+GenerateTaxonomy(tree, taxizepref='ncbi')
 }
 \arguments{
   \item{tree}{
@@ -15,9 +15,6 @@ An object of type 'phy', a rooted phylogeny. Multifurcating trees are accepted, 
 }
   \item{taxizepref}{
 Your choice of database: could be one of 'ncbi, itis, eol, col, tropicos, gbif, nbn, worms, natserv, bold,' or 'wiki'. See ?taxize::classification for more info.
-}
-\item{purgerankless}{
-Some databases return entries for unnamed ranks: NCBI returns a level for "cellular organisms" that has no formal rank. If TRUE, such entries are deleted.
 }
 }
 \details{
@@ -31,9 +28,4 @@ Brian O'Meara
 }
 \seealso{
 \code{\link{GetAncNodes}}, \code{\link{GetIntruderTaxa}}, \code{\link{GetIntruderTips}}, \code{\link{GetOutlierTaxa}}, \code{\link{GetOutlierTips}},\code{\link{GetResultMonophyly}}, \code{\link{GetSummaryMonophyly}}, \code{\link{MonophylyData}}, \code{\link{PlotMonophyly}}, \code{\link{MonoPhy-package}}
-}
-\examples{
-data(Ericactree)  # load tree
-taxonomy <- GenerateTaxonomy(Ericactree)
-print(head(taxonomy))
 }


### PR DESCRIPTION
Had a tree with hundreds of species. Two had numbers for names. Now it can optionally toss out species that don't match genus_species if this happens (but will still stop if *no* species match)